### PR TITLE
Add Snake example problem

### DIFF
--- a/examples/snake/evaluator.py
+++ b/examples/snake/evaluator.py
@@ -1,0 +1,37 @@
+"""
+Evaluation entry-point for OpenEvolve.
+
+OpenEvolve will import this module and call evaluate(program_path, config),
+where program_path is the path to the candidate npc_player.py after patching
+in the LLM-generated EVOLVE code.
+
+We run N episodes with different seeds and return average score & length.
+"""
+
+import importlib.util
+import statistics
+from pathlib import Path
+from game import Game
+from player_base import PlayerBase
+
+EPISODES = 5   # increase for harder eval
+
+def _load_player(candidate_file: Path) -> PlayerBase:
+    spec = importlib.util.spec_from_file_location("npc_player", candidate_file)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.EvolvedPlayer()
+
+def evaluate(candidate_file, config=None):
+    scores, lengths = [], []
+    for seed in range(EPISODES):
+        player = _load_player(Path(candidate_file))
+        g = Game(rows=12, cols=12, max_steps=200)
+        score, steps = g.play(player, seed=seed)
+        scores.append(score)
+        lengths.append(steps)
+
+    return {
+        "avg_score": statistics.mean(scores),
+        "avg_steps": statistics.mean(lengths),
+    }

--- a/examples/snake/game.py
+++ b/examples/snake/game.py
@@ -1,0 +1,124 @@
+"""
+A minimal head-less Snake engine suitable for evolutionary code search.
+Grid coordinates: (0,0)=top-left.  Direction vectors: U,D,L,R.
+Game ends on wall collision or self-collision, or when max_steps reached.
+"""
+
+from enum import Enum
+import random
+
+class Direction(Enum):
+    UP    = ( -1,  0)
+    DOWN  = (  1,  0)
+    LEFT  = (  0, -1)
+    RIGHT = (  0,  1)
+
+OPPOSITE = {
+    Direction.UP:    Direction.DOWN,
+    Direction.DOWN:  Direction.UP,
+    Direction.LEFT:  Direction.RIGHT,
+    Direction.RIGHT: Direction.LEFT,
+}
+
+class Game:
+    def __init__(self, rows=12, cols=12, max_steps=200):
+        self.rows = rows
+        self.cols = cols
+        self.max_steps = max_steps
+        self.reset()
+
+    # ------------------------------------------------------------------ utils
+    def reset(self):
+        mid_r, mid_c = self.rows // 2, self.cols // 2
+        self.snake = [(mid_r, mid_c)]
+        self.dir = random.choice(list(Direction))
+        self.spawn_food()
+        self.steps = 0
+        self.score = 0
+        self.alive = True
+
+    def spawn_food(self):
+        cells = {(r, c) for r in range(self.rows) for c in range(self.cols)}
+        cells -= set(self.snake)
+        self.food = random.choice(list(cells))
+
+    # ---------------------------------------------------------------- sensors
+    def get_sensor(self):
+        """Return a lightweight dictionary visible to the player."""
+        head_r, head_c = self.snake[0]
+
+        # Manhattan distance to food
+        food_vec = (self.food[0] - head_r, self.food[1] - head_c)
+
+        # one-hot collision danger in each direction (wall or body)
+        danger = {}
+        for d in Direction:
+            dr, dc = d.value
+            r, c = head_r + dr, head_c + dc
+            danger[d.name] = (
+                r < 0 or r >= self.rows or
+                c < 0 or c >= self.cols or
+                (r, c) in self.snake
+            )
+
+        return {
+            "food_vec": food_vec,
+            "danger": danger,
+            "current_dir": self.dir.name,
+            "length": len(self.snake),
+            "steps": self.steps,
+        }
+
+    # -------------------------------------------------------------- game step
+    def step(self, action: str):
+        """Advance one tick given an action string ('UP','DOWN',...)."""
+        if not self.alive:
+            return
+
+        try:
+            chosen = Direction[action.upper()]
+        except KeyError:
+            chosen = self.dir  # illegal text -> keep going straight
+
+        # Disallow 180-degree turn
+        if chosen == OPPOSITE[self.dir]:
+            chosen = self.dir
+        self.dir = chosen
+
+        # move head
+        dr, dc = self.dir.value
+        head_r, head_c = self.snake[0]
+        new_head = (head_r + dr, head_c + dc)
+        self.steps += 1
+
+        # collisions
+        r, c = new_head
+        if (r < 0 or r >= self.rows or
+            c < 0 or c >= self.cols or
+            new_head in self.snake):
+            self.alive = False
+            return
+
+        # eat
+        ate = new_head == self.food
+        self.snake.insert(0, new_head)
+        if ate:
+            self.score += 1
+            self.spawn_food()
+        else:
+            self.snake.pop()  # move tail
+
+        if self.steps >= self.max_steps:
+            self.alive = False
+
+    # -------------------------------------------------------- run full episode
+    def play(self, player, seed=None):
+        """Run to termination with the supplied Player object."""
+        if seed is not None:
+            random.seed(seed)
+        self.reset()
+        while self.alive:
+            sensors = self.get_sensor()
+            action = player.decide(sensors)
+            self.step(action)
+        return self.score, self.steps

--- a/examples/snake/npc_player.py
+++ b/examples/snake/npc_player.py
@@ -1,0 +1,40 @@
+from player_base import PlayerBase
+from game import Direction
+
+class EvolvedPlayer(PlayerBase):
+    """
+    Initial naive policy (baseline).  OpenEvolve will edit ONLY the code
+    inside the marked region.  Outside code stays static for context.
+    """
+
+    # EVOLVE-BLOCK-START
+    def decide(self, sensors):
+        """
+        sensors: {
+            'food_vec': (dr, dc),
+            'danger': {'UP':bool, 'DOWN':bool, ...},
+            'current_dir': 'UP'|'DOWN'|'LEFT'|'RIGHT',
+            'length': int,
+            'steps': int
+        }
+        Must return one of 'UP','DOWN','LEFT','RIGHT'
+        """
+        # REFERENCE  policy: greedily move toward food if safe, else turn right
+        head_to_food = sensors["food_vec"]
+        danger = sensors["danger"]
+
+        # pick axis with larger |delta|
+        vertical = abs(head_to_food[0]) >= abs(head_to_food[1])
+        if vertical:
+            move = "UP" if head_to_food[0] < 0 else "DOWN"
+        else:
+            move = "LEFT" if head_to_food[1] < 0 else "RIGHT"
+
+        # avoid collisions
+        if danger[move]:
+            for alt in ["UP", "RIGHT", "DOWN", "LEFT"]:
+                if not danger[alt]:
+                    move = alt
+                    break
+        return move
+    # EVOLVE-BLOCK-END

--- a/examples/snake/player_base.py
+++ b/examples/snake/player_base.py
@@ -1,0 +1,8 @@
+class PlayerBase:
+    """
+    Sub-classes must implement:
+        decide(sensor_dict) -> str   (returns 'UP','DOWN','LEFT','RIGHT')
+    """
+
+    def decide(self, sensors):
+        raise NotImplementedError("Players must override decide()")

--- a/examples/snake/snake_config.yaml
+++ b/examples/snake/snake_config.yaml
@@ -1,0 +1,17 @@
+max_iterations: 200
+
+database:
+  population_size: 64
+  num_islands: 4
+  exploitation_ratio: 0.2
+
+llm:
+  models:
+    - name: mistral-local
+      temperature: 0.7
+    - name: deepseek-r1-local
+      temperature: 0.7
+
+prompt:
+  num_top_programs: 2
+  num_diverse_programs: 3


### PR DESCRIPTION
## Summary
- add a headless Snake game engine and player interface
- include an evolvable NPC player with marked EVOLVE block
- implement evaluator to average performance across episodes
- supply configuration for running OpenEvolve on the Snake game

## Testing
- `pytest tests/test_valid_configs.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6846c88efb70832a9d983bff484ea8d2