### PR TITLE
Fix dynamic imports for snake evaluator

### DIFF
--- a/examples/snake/evaluator.py
+++ b/examples/snake/evaluator.py
@@ -11,6 +11,15 @@ We run N episodes with different seeds and return average score & length.
 import importlib.util
 import statistics
 from pathlib import Path
+import sys
+import os
+
+# Ensure local modules like `game` and `player_base` can be imported when this
+# file is loaded dynamically via ``importlib``. OpenEvolve loads the evaluation
+# function using ``spec_from_file_location`` which does not automatically add
+# the file's directory to ``sys.path``.
+sys.path.insert(0, os.path.dirname(__file__))
+
 from game import Game
 from player_base import PlayerBase
 


### PR DESCRIPTION
## Summary
- adjust `examples/snake/evaluator.py` to add its directory to `sys.path`
- ensures `game` and `player_base` modules resolve when running in Docker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ce1c2d2c832a9dab2130e6cbd51e